### PR TITLE
feat: Add 'Go to Story URL' button in library

### DIFF
--- a/plugin/_locales/en/messages.json
+++ b/plugin/_locales/en/messages.json
@@ -71,6 +71,10 @@
 		"message": "Edit Metadata",
 		"description": "Label on button to show edit options for metadata"
 	},
+	"__MSG_button_Lib_Template_Go_To_Story_URL__": {
+		"message": "Go to Story URL",
+		"description": "Label on button to open the story URL in a new tab"
+	},
 	"__MSG_label_Lib_Template_Library_uses__": {
 		"message": "Library uses: ",
 		"description": "Label in front of the Bytes used in local Storage"

--- a/plugin/js/Library.js
+++ b/plugin/js/Library.js
@@ -337,6 +337,7 @@ class Library {
         let LibTemplateNewChapter = document.getElementById("LibTemplateNewChapter").innerHTML;
         let LibTemplateURL = document.getElementById("LibTemplateURL").innerHTML;
         let LibTemplateFilename = document.getElementById("LibTemplateFilename").innerHTML;
+        let LibTemplateGoToStoryURL = document.getElementById("LibTemplateGoToStoryURL").innerHTML;
         let LibTemplateMergeUploadButton = "";
         let LibTemplateEditMetadataButton = "";
 
@@ -422,6 +423,7 @@ class Library {
                 LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibDeleteEpub"+CurrentLibKeys[i]+"'>"+LibTemplateDeleteEpub+"</button>";
                 LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibUpdateNewChapter"+CurrentLibKeys[i]+"'>"+LibTemplateUpdateNewChapter+"</button>";
                 LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibDownload"+CurrentLibKeys[i]+"'>"+LibTemplateDownload+"</button>";
+                LibRenderString += "<button data-libepubid="+CurrentLibKeys[i]+" id='LibGoToStoryURL"+CurrentLibKeys[i]+"'>"+LibTemplateGoToStoryURL+"</button>";
                 LibRenderString += "<span style='padding: 1em; font-size: 1.2em; color: Chartreuse;' id='LibNewChapterCount"+CurrentLibKeys[i]+"'></span>";
                 if (ShowAdvancedOptions) {
                     LibRenderString += "</td>";
@@ -479,6 +481,7 @@ class Library {
                 document.getElementById("LibDeleteEpub"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibDeleteEpub(this)});
                 document.getElementById("LibUpdateNewChapter"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibUpdateNewChapter(this)});
                 document.getElementById("LibDownload"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibDownload(this)});
+                document.getElementById("LibGoToStoryURL"+CurrentLibKeys[i]).addEventListener("click", function(){Library.LibGoToStoryURL(this)});
                 document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("change", function(){Library.LibSaveTextURLChange(this)});
                 document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("focusin", function(){Library.LibShowTextURLWarning(this)});
                 document.getElementById("LibStoryURL"+CurrentLibKeys[i]).addEventListener("focusout", function(){Library.LibHideTextURLWarning(this)});
@@ -799,6 +802,13 @@ class Library {
         Library.userPreferences.readingList.tryDeleteEpubAndSave(document.getElementById("LibStoryURL" + objbtn.dataset.libepubid).value);
         chrome.storage.local.remove(LibRemove);
         Library.LibRenderSavedEpubs();
+    }
+
+    static async LibGoToStoryURL(objbtn) {
+        let storyUrl = await Library.LibGetFromStorage("LibStoryURL" + objbtn.dataset.libepubid);
+        if (storyUrl) {
+            chrome.tabs.create({ url: storyUrl });
+        }
     }
 
     static async LibUpdateNewChapter(objbtn){

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -191,6 +191,11 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td colspan="2">
+                                    <button id="LibTemplateGoToStoryURL">__MSG_button_Lib_Template_Go_To_Story_URL__</button>
+                                </td>
+                            </tr>
+                            <tr>
                                 <td id="LibTemplateNewChapter">__MSG_label_Lib_Template_New_Chapter__</td><td style="padding:0;">
                                 <td id="LibTemplateURL">__MSG_label_Lib_Template_Story_URL__</td><td style="padding:0;">
                                     <table style="border-spacing:0;">


### PR DESCRIPTION
This commit introduces a new button in the library view for each novel entry. This button, labeled 'Go to Story URL', allows users to directly open the novel's original URL in a new tab.

This provides a workaround for cases where the 'Update' or 'Search for New Chapter' functionality might not work for certain websites, giving users a reliable way to access the source and manually check for updates.